### PR TITLE
Preparation for GitHub Marketplace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: "test"
 on:
-  pull_request:
   push:
-    branches:
-      - master
 
 jobs:
   test: # make sure the action works on a clean machine without building

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 NetEngine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ source repository and branch to any destination, or copying all branches.
 
 * Support for any to and from branch, similar to [actions/checkout@v2](https://github.com/actions/checkout)
 * Make SSH key-based authentication optional to support username/password authentication
-* Support for the [pull_request event](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request)
+* Support for the `pull_request` [event](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request)
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-gs<p align="center">
-  <a href="https://github.com/net-engine/github-repository-sync-action"><img alt="GitHub action build status" src="https://github.com/net-engine/github-repository-sync-action/workflows/test/badge.svg"></a>
+<p align="center">
+  <a href="https://github.com/net-engine/github-repository-sync-action">
+    <img alt="GitHub Action build status" src="https://github.com/net-engine/github-repository-sync-action/workflows/test/badge.svg">
+  </a>
 </p>
 
 # Git Repository Sync Action
 
 This action pushes all commits in the branch that this action is run on into any remote git repository.
 
-Check out a [sample workflow](https://github.com/net-engine/github-repository-sync-action/blob/master/.github/workflows/test.yml).
+Check out a [sample workflow](.github/workflows/test.yml).
 
 ## Usage
 
@@ -37,6 +39,7 @@ source repository and branch to any destination, or copying all branches.
 
 * Support for any to and from branch, similar to [actions/checkout@v2](https://github.com/actions/checkout)
 * Make SSH key-based authentication optional to support username/password authentication
+* Support for the [pull_request event](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request)
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,43 @@
 <p align="center">
-  <a href="https://github.com/net-engine/github-repository-sync-action"><img alt="GitHub action build status" src="https://github.com/net-engine/github-repository-sync-action/workflows/build-test/badge.svg"></a>
+  <a href="https://github.com/net-engine/github-repository-sync-action"><img alt="GitHub action build status" src="https://github.com/net-engine/github-repository-sync-action/workflows/test/badge.svg"></a>
 </p>
 
 # Git Repository Sync Action
 
-A [GitHub action](https://github.com/features/actions) to push changes to a branch in a current GitHub repository to any remote repository, i.e. another GitHub, GitLab, AWS CodeCommit repository.
+This action pushes all commits in the branch that this action is run on into any remote git repository.
 
 Check out a [sample workflow](https://github.com/net-engine/github-repository-sync-action/blob/master/.github/workflows/test.yml).
 
-Inspired by the following actions
+## Usage
+
+Be sure to run the [`actions/checkout`](https://github.com/actions/checkout) action in a step before
+this action so that the git repository is initialized.
+
+```yaml
+# File: .github/workflows/mirror.yml
+- uses: netengine/github-repository-sync-action@v1
+  with:
+    # The SSH private key for SSH connection to the target repository.
+    # We strongly recommend saving this value as a GitHub Secret and using deploy
+    # keys within the target repository
+    ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+    # The SSH-based URL to the target repository
+    target_repo_url: git@github.com:net-engine/github-repository-sync-action-test.git
+```
+
+## Notes
+
+Inspired by the following actions which may be more suitable for your workflow, e.g. syncing any
+source repository and branch to any destination, or copying all branches.
 
 * [wei/git-sync](https://github.com/wei/git-sync)
 * [pixta-dev/repository-mirroring-action](https://github.com/pixta-dev/repository-mirroring-action)
-
-## Inputs
-
-### `ssh_private_key`
-
-**Required** The SSH private key for SSH connection to the target repository. We strongly recommend saving this value within [GitHub secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets).
-
-### `target_repo_url`
-
-**Required** The SSH-based URL to the target repository, e.g. `git@github.com:net-engine/github-repository-sync-action.git`
-
-## Example usage
-
-uses: netengine/github-repository-sync-action
-with:
-  who-to-greet: 'Mona the Octocat'
 
 ## TODO
 
 * Support for any to and from branch, similar to [actions/checkout@v2](https://github.com/actions/checkout)
 * Make SSH key-based authentication optional to support username/password authentication
+
+# License
+
+The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+gs<p align="center">
   <a href="https://github.com/net-engine/github-repository-sync-action"><img alt="GitHub action build status" src="https://github.com/net-engine/github-repository-sync-action/workflows/test/badge.svg"></a>
 </p>
 
@@ -40,4 +40,4 @@ source repository and branch to any destination, or copying all branches.
 
 # License
 
-The scripts and documentation in this project are released under the [MIT License](LICENSE)
+The scripts and documentation in this project are released under the [MIT License](LICENSE.md)


### PR DESCRIPTION
This PR
* Updates various documentation in preparation for listing on the [GitHub Marketplace](https://github.com/marketplace?type=actions)
* Simplifies usage section
* Adds the MIT license


- [x] Update [release](https://github.com/net-engine/github-repository-sync-action/releases) page to be semver with changelogs