### PR TITLE
Fix typo in README action reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ this action so that the git repository is initialized.
 
 ```yaml
 # File: .github/workflows/mirror.yml
-- uses: netengine/github-repository-sync-action@v1
+- uses: net-engine/github-repository-sync-action@v1
   with:
     # The SSH private key for SSH connection to the target repository.
     # We strongly recommend saving this value as a GitHub Secret and using deploy


### PR DESCRIPTION
My mistake. Our organization name is `net-engine not `netengine`.